### PR TITLE
Refs #cbr-14: some styling additions, axis, and small fixes.

### DIFF
--- a/css/bargraph.css
+++ b/css/bargraph.css
@@ -5,9 +5,5 @@
  * @copyright Copyright (c) 2015 Palantir.net
  */
 .bar-graph {
-    background-color: #064771;
-}
-
-.bar-graph {
-    background-color: #064771;
+  background-color: #F5F5F5;
 }

--- a/semantics.json
+++ b/semantics.json
@@ -5,7 +5,7 @@
     "label": "Bar color",
     "description": "The default color for the bars in this chart.",
     "optional": true,
-    "default": "064771",
+    "default": "E0196A",
     "widget": "colorSelector",
     "spectrum": {
       "showInput": true
@@ -41,6 +41,10 @@
           "name": "barColor",
           "type": "text",
           "widget": "colorSelector",
+          "default": "56C5D0",
+          "spectrum": {
+            "showInput": true
+          },
           "label": "Override Color",
           "description": "The color to use for this bar instead of the chart default.",
           "optional": true


### PR DESCRIPTION
Mainly some styling improvements, addition of x + y axis and some small fixes.

To test:
- Start with https://github.com/palantirnet/booth/pull/29 branch
- Download all h5p libraries to get dependencies 
  *\* https://h5p.org/sites/default/files/all-h5p-libraries-20151110.h5p
- Change the file path setting at admin/config/system/h5p to reside in the sites/default/files/h5p directory (can't upload h5p dependencies otherwise.)
- Enable development mode from the same page
- Copy the h5p-bargraph into the sites/files/h5p/development directory
- Create a new interactive content
- Select h5p bargraph from the select list and add data points / color options.
- Profit!

![test_graph___booth](https://cloud.githubusercontent.com/assets/394763/11941588/5136ae9e-a7f6-11e5-9097-d2f06ffaeacb.png)
